### PR TITLE
Remove /var/tmp/cellery while cleaning up cellery setup on kubeadm

### DIFF
--- a/integration-tests/setups/existing-cluster/kube-admin/cleanup.sh
+++ b/integration-tests/setups/existing-cluster/kube-admin/cleanup.sh
@@ -21,6 +21,9 @@ log_info() {
     echo "${log_prefix}[INFO]" $1
 }
 sudo mv /etc/hosts.back /etc/hosts
+if [ -d /var/tmp/cellery ]; then
+    rm -rf /var/tmp/cellery
+fi
 log_info "Destroying kubeadmin cellery setup..."
 cellery setup cleanup existing -y
 


### PR DESCRIPTION
## Purpose
> Contains additions to remove  /var/tmp/cellery when cleaning up cellery setup on kubeadm