### PR TITLE
Fix permission issue in deleting /var/tmp/cellery

### DIFF
--- a/integration-tests/setups/existing-cluster/kube-admin/cleanup.sh
+++ b/integration-tests/setups/existing-cluster/kube-admin/cleanup.sh
@@ -22,7 +22,7 @@ log_info() {
 }
 sudo mv /etc/hosts.back /etc/hosts
 if [ -d /var/tmp/cellery ]; then
-    rm -rf /var/tmp/cellery
+    sudo rm -rf /var/tmp/cellery
 fi
 log_info "Destroying kubeadmin cellery setup..."
 cellery setup cleanup existing -y


### PR DESCRIPTION
## Purpose
> Contains necessary modifications to fix permission issue in deleting /var/tmp/cellery after kubeadmin is run in persistent mode