### PR TITLE
Add initial test cases for employee portal scenario test

### DIFF
--- a/integration-tests/test-cases/cells/employee-portal/hr/hr.bal
+++ b/integration-tests/test-cases/cells/employee-portal/hr/hr.bal
@@ -26,8 +26,8 @@ cellery:Component hrComponent = {
         stock_api_url: { value: "" }
     },
     dependencies: {
-        employeeCellDep: "myorg/employee:1.0.0", //  fully qualified dependency image name as a string
-        stockCellDep: <cellery:ImageName>{ org: "myorg", name: "stock", ver: "1.0.0" } // dependency as a struct
+        employeeCellDep: "wso2cellerytest/employee-cell:1.0.0", //  fully qualified dependency image name as a string
+        stockCellDep: <cellery:ImageName>{ org: "wso2cellerytest", name: "stock-cell", ver: "1.0.0" } // dependency as a struct
     }
 };
 
@@ -45,10 +45,10 @@ public function build(cellery:ImageName iName) returns error? {
 public function run(cellery:ImageName iName, map<cellery:ImageName> instances) returns error? {
     //Resolve employee API URL
     cellery:Reference employeeRef = check cellery:getReference(instances.employeeCellDep);
-    hrCell.components.hrComp.envVars.employee_api_url.value = <string>employeeRef.employee_api_url;
+    hrComponent.envVars.employee_api_url.value = <string>employeeRef.employee_api_url;
 
     //Resolve stock API URL
     cellery:Reference stockRef = check cellery:getReference(instances.stockCellDep);
-    hrCell.components.hrComp.envVars.stock_api_url.value = <string>stockRef.stock_api_url;
+    hrComponent.envVars.stock_api_url.value = <string>stockRef.stock_api_url;
     return cellery:createInstance(hrCell, iName);
 }

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/BaseTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/BaseTestCase.java
@@ -84,15 +84,17 @@ public class BaseTestCase {
     }
 
     protected String run(String orgName, String imageName, String version, String instanceName,
-                                       String link, boolean startDependencies, int timeoutSec)
+                                       String[] links, boolean startDependencies, int timeoutSec)
             throws Exception {
         String cellImageName = getCellImageName(orgName, imageName, version);
         String command = CELLERY_RUN + " " + cellImageName + " -y";
         if (instanceName != null && !instanceName.isEmpty()) {
             command += " -n " + instanceName;
         }
-        if (link != null && !link.isEmpty()) {
-            command += " -l " + link;
+        if (links != null && links.length != 0) {
+            for (int i = 0; i < links.length; i++) {
+                command += " -l " + links[i];
+            }
         }
         if (startDependencies) {
             command += " -d";

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/BaseTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/BaseTestCase.java
@@ -31,12 +31,14 @@ import java.util.stream.Collectors;
  */
 public class BaseTestCase {
     private static final String SUCCESSFUL_BUILD_MSG = "Successfully built cell image";
+    private static final String SUCCESSFUL_DELETE_MSG = "";
     private static final String SUCCESSFUL_RUN_MSG = "Successfully deployed cell image";
 
     private static final String INSTANCE_NAME_HEADING = "INSTANCE NAME";
     private static final String CELLERY_AUTOMATION_TESTS_ROOT_ENV = "CELLERY_AUTOMATION_TESTS_ROOT";
 
     private static final String CELLERY_BUILD = "cellery build";
+    private static final String CELLERY_DELETE = "cellery delete";
     private static final String CELLERY_RUN = "cellery run";
     private static final String CELLERY_STATUS = "cellery status";
     private static final String CELLERY_TERM = "cellery term";
@@ -92,9 +94,11 @@ public class BaseTestCase {
             command += " -n " + instanceName;
         }
         if (links != null && links.length != 0) {
-            for (int i = 0; i < links.length; i++) {
-                command += " -l " + links[i];
+            StringBuffer buffer = new StringBuffer();
+            for (int i = 0; i < links.length; ++i) {
+                buffer.append(" -l " + links[i]);
             }
+            command += buffer.toString();
         }
         if (startDependencies) {
             command += " -d";
@@ -171,5 +175,11 @@ public class BaseTestCase {
 
     protected void validateWebPage(String expected, String actual, String error) {
         Assert.assertEquals(expected, actual, error);
+    }
+
+    protected void delete(String cellImageName) throws Exception {
+        Process process = Runtime.getRuntime().exec(CELLERY_DELETE + " " + cellImageName);
+        String errorString = "Unable to delete cell image: " + cellImageName;
+        readOutputResult(process, SUCCESSFUL_DELETE_MSG, errorString);
     }
 }

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.cellery.integration.scenario.tests;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.nio.file.Paths;
+
+/**
+ * This includes the test cases related to employee portal.
+ */
+public class EmployeePortalTestCase extends BaseTestCase {
+    private static final String STOCK_INSTANCE_NAME = "stock-inst";
+    private static final String STOCK_IMAGE_NAME = "stock-cell";
+    private static final String EMPLOYEE_INSTANCE_NAME = "employee-inst";
+    private static final String EMPLOYEE_IMAGE_NAME = "employee-cell";
+    private static final String HR_INSTANCE_NAME = "hr-inst";
+    private static final String HR_IMAGE_NAME = "hr-cell";
+    private static final String VERSION = "1.0.0";
+    private static final String LINK_STOCK = "stockCellDep:stock-inst";
+    private static final String LINK_EMPLOYEE = "employeeCellDep:employee-inst";
+
+    @Test
+    public void buildStock() throws Exception {
+        build("stocks.bal", Constants.TEST_CELL_ORG_NAME, STOCK_IMAGE_NAME, VERSION,
+                Paths.get(CELLERY_SCENARIO_TEST_ROOT, "employee-portal", "stock").toFile().getAbsolutePath());
+    }
+
+    @Test
+    public void runStock() throws Exception {
+        run(Constants.TEST_CELL_ORG_NAME, STOCK_IMAGE_NAME, VERSION, STOCK_INSTANCE_NAME, 120);
+    }
+
+    @Test
+    public void buildEmployee() throws Exception {
+        build("employee.bal", Constants.TEST_CELL_ORG_NAME, EMPLOYEE_IMAGE_NAME, VERSION,
+                Paths.get(CELLERY_SCENARIO_TEST_ROOT, "employee-portal", "employee").toFile().getAbsolutePath());
+    }
+
+    @Test
+    public void runEmployee() throws Exception {
+        run(Constants.TEST_CELL_ORG_NAME, EMPLOYEE_IMAGE_NAME, VERSION, EMPLOYEE_INSTANCE_NAME, 120);
+    }
+
+    @Test
+    public void buildHr() throws Exception {
+        build("hr.bal", Constants.TEST_CELL_ORG_NAME, HR_IMAGE_NAME, VERSION,
+                Paths.get(CELLERY_SCENARIO_TEST_ROOT, "employee-portal", "hr").toFile().getAbsolutePath());
+    }
+
+    @Test
+    public void runHr() throws Exception {
+        String[] links = new String[]{LINK_STOCK, LINK_EMPLOYEE};
+        run(Constants.TEST_CELL_ORG_NAME, HR_IMAGE_NAME, VERSION, HR_INSTANCE_NAME, links, false,
+                120);
+    }
+
+    @Test
+    public void terminate() throws Exception {
+        terminateCell(HR_INSTANCE_NAME);
+        terminateCell(EMPLOYEE_INSTANCE_NAME);
+        terminateCell(STOCK_INSTANCE_NAME);
+    }
+
+    @AfterClass
+    public void cleanup() {
+        try {
+            terminateCell(HR_INSTANCE_NAME);
+            terminateCell(EMPLOYEE_INSTANCE_NAME);
+            terminateCell(STOCK_INSTANCE_NAME);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
@@ -72,6 +72,13 @@ public class EmployeePortalTestCase extends BaseTestCase {
     }
 
     @Test
+    public void deleteImages() throws Exception {
+        delete(Constants.TEST_CELL_ORG_NAME + "/" + HR_IMAGE_NAME + ":" + VERSION);
+        delete(Constants.TEST_CELL_ORG_NAME + "/" + EMPLOYEE_IMAGE_NAME + ":" + VERSION);
+        delete(Constants.TEST_CELL_ORG_NAME + "/" + STOCK_IMAGE_NAME + ":" + VERSION);
+    }
+
+    @Test
     public void terminate() throws Exception {
         terminateCell(HR_INSTANCE_NAME);
         terminateCell(EMPLOYEE_INSTANCE_NAME);

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/HelloworldWebTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/HelloworldWebTestCase.java
@@ -73,6 +73,11 @@ public class HelloworldWebTestCase extends BaseTestCase {
         terminateCell(HELLO_WORLD_INSTANCE);
     }
 
+    @Test
+    public void deleteImage() throws Exception {
+        delete(Constants.TEST_CELL_ORG_NAME + "/" + IMAGE_NAME + ":" + VERSION);
+    }
+
     private void validateWebPage() {
         String searchHeader = webDriver.findElement(By.cssSelector("H1")).getText().toLowerCase();
         Assert.assertEquals(searchHeader, Constants.HELLO_WORLD_WEB_CONTENT, "Web page is content is not as expected");

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/cli/ImageBasedTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/cli/ImageBasedTestCase.java
@@ -119,4 +119,10 @@ public class ImageBasedTestCase extends BaseTestCase {
         String expectedOut = "Successfully extracted cell image resources: " + cellImageName;
         readOutputResult(process, expectedOut, errorString);
     }
+
+    @Test(dependsOnMethods = "extractResourceImageWithProvidedOutput")
+    public void deleteImages() throws Exception {
+        delete(Constants.TEST_CELL_ORG_NAME + "/" + EMPLOYEE_IMAGE + ":" + Constants.SAMPLE_CELLS_VERSION);
+        delete(Constants.TEST_CELL_ORG_NAME + "/" + HELLO_WORLD_IMAGE + ":" + Constants.SAMPLE_CELLS_VERSION);
+    }
 }

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/cli/InstanceBasedTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/cli/InstanceBasedTestCase.java
@@ -61,6 +61,11 @@ public class InstanceBasedTestCase extends BaseTestCase {
         }
     }
 
+    @Test(dependsOnMethods = "describeNonExistingInstance")
+    public void deleteImages() throws Exception {
+        delete(ORGANIZATION_NAME + "/" + IMAGE_NAME + ":" + Constants.SAMPLE_CELLS_VERSION);
+    }
+
     @AfterClass
     public void cleanup() throws Exception {
         terminateCell(instanceName);

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
@@ -163,6 +163,12 @@ public class PetStoreTestCase extends BaseTestCase {
         terminateCell(FRONTEND_INSTANCE_NAME);
     }
 
+    @Test
+    public void deleteImages() throws Exception {
+        delete(Constants.CELL_ORG_NAME + "/" + BACKEND_IMAGE_NAME + ":" + VERSION);
+        delete(Constants.CELL_ORG_NAME + "/" + FRONTEND_IMAGE_NAME + ":" + VERSION);
+    }
+
     @AfterClass
     public void cleanup() {
         webDriver.close();

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
@@ -102,7 +102,8 @@ public class PetStoreTestCase extends BaseTestCase {
 
     @Test(description = "Tests the running of pet store front end instance.")
     public void runFrontEnd() throws Exception {
-        run(Constants.CELL_ORG_NAME, FRONTEND_IMAGE_NAME, VERSION, FRONTEND_INSTANCE_NAME, LINK, false,
+        String[] links = new String[]{LINK};
+        run(Constants.CELL_ORG_NAME, FRONTEND_IMAGE_NAME, VERSION, FRONTEND_INSTANCE_NAME, links, false,
                 600);
     }
 

--- a/integration-tests/test-cases/scenario-tests/src/test/resources/basic.xml
+++ b/integration-tests/test-cases/scenario-tests/src/test/resources/basic.xml
@@ -30,6 +30,7 @@
                     <include name="invoke"/>
                     <include name="terminate"/>
                     <include name="repeatTerminate"/>
+                    <include name="deleteImage"/>
                 </methods>
             </class>
             <class name="io.cellery.integration.scenario.tests.EmployeePortalTestCase">
@@ -40,6 +41,7 @@
                     <include name="runEmployee"/>
                     <include name="buildHr"/>
                     <include name="runHr"/>
+                    <include name="deleteImages"/>
                     <include name="terminate"/>
                 </methods>
             </class>
@@ -58,6 +60,7 @@
                     <include name="checkOrdersBob"/>
                     <include name="signOutBob"/>
                     <include name="terminate"/>
+                    <include name="deleteImages"/>
                 </methods>
             </class>
         </classes>

--- a/integration-tests/test-cases/scenario-tests/src/test/resources/basic.xml
+++ b/integration-tests/test-cases/scenario-tests/src/test/resources/basic.xml
@@ -32,6 +32,17 @@
                     <include name="repeatTerminate"/>
                 </methods>
             </class>
+            <class name="io.cellery.integration.scenario.tests.EmployeePortalTestCase">
+                <methods>
+                    <include name="buildStock"/>
+                    <include name="runStock"/>
+                    <include name="buildEmployee"/>
+                    <include name="runEmployee"/>
+                    <include name="buildHr"/>
+                    <include name="runHr"/>
+                    <include name="terminate"/>
+                </methods>
+            </class>
             <class name="io.cellery.integration.scenario.tests.petstore.PetStoreTestCase">
                 <methods>
                     <include name="buildBackEnd"/>

--- a/integration-tests/test-cases/scenario-tests/src/test/resources/complete.xml
+++ b/integration-tests/test-cases/scenario-tests/src/test/resources/complete.xml
@@ -30,6 +30,7 @@
                     <include name="invoke"/>
                     <include name="terminate"/>
                     <include name="repeatTerminate"/>
+                    <include name="deleteImage"/>
                 </methods>
             </class>
             <class name="io.cellery.integration.scenario.tests.EmployeePortalTestCase">
@@ -40,6 +41,7 @@
                     <include name="runEmployee"/>
                     <include name="buildHr"/>
                     <include name="runHr"/>
+                    <include name="deleteImages"/>
                     <include name="terminate"/>
                 </methods>
             </class>
@@ -58,6 +60,7 @@
                     <include name="checkOrdersBob"/>
                     <include name="signOutBob"/>
                     <include name="terminate"/>
+                    <include name="deleteImages"/>
                 </methods>
             </class>
         </classes>

--- a/integration-tests/test-cases/scenario-tests/src/test/resources/complete.xml
+++ b/integration-tests/test-cases/scenario-tests/src/test/resources/complete.xml
@@ -32,6 +32,17 @@
                     <include name="repeatTerminate"/>
                 </methods>
             </class>
+            <class name="io.cellery.integration.scenario.tests.EmployeePortalTestCase">
+                <methods>
+                    <include name="buildStock"/>
+                    <include name="runStock"/>
+                    <include name="buildEmployee"/>
+                    <include name="runEmployee"/>
+                    <include name="buildHr"/>
+                    <include name="runHr"/>
+                    <include name="terminate"/>
+                </methods>
+            </class>
             <class name="io.cellery.integration.scenario.tests.petstore.PetStoreTestCase">
                 <methods>
                     <include name="buildBackEnd"/>


### PR DESCRIPTION
* Build, run and terminate test cases for stock, employee and hr cells were added.
* Run method in Base test cases was updated to expect an array of dependencies.
* Cell image deletion test cases were added using cellery delete command.
