### PR TITLE
Update hr api name in employee portal tests case

### DIFF
--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
@@ -51,7 +51,7 @@ public class EmployeePortalTestCase extends BaseTestCase {
     private static final String LINK_HR_TO_STOCK = "stockCellDep:stock-inst";
     private static final String LINK_HR_TO_EMPLOYEE = "employeeCellDep:employee-inst";
     private static final String HR_URL = "https://wso2-apim-gateway/hr-inst/hr";
-    private static final String HR_INST_API = "hr_inst_global_1_0_0_hr_api";
+    private static final String HR_INST_API = "hr_inst_global_1_0_0_hr";
     private static final String AUTHENTICATION_TYPE_BEARER = "Bearer";
 
     protected String employeeBalFile;


### PR DESCRIPTION
Fix integration tests failure due to an incorrect hr api name in employee portal test cases.