### PR TITLE
Add validation to check if runtime is gcp

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -19,6 +19,7 @@ PROJECT_ROOT := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 USERNAME ?= celleryio
 PASSWORD ?= celleryio
 CELLERY_REGISTRY ?= registry-1.docker.io
+GCP_CLUSTER ?= false
 
 run-local-basic: setup-local-basic test-basic cleanup-local
 run-local-complete: setup-local-complete test-complete cleanup-local
@@ -48,12 +49,14 @@ remove-samples:
 .PHONY: test-basic
 test-basic: clone-samples
 	cd $(PROJECT_ROOT)/test-cases/scenario-tests/; \
+	export IS_GCP=$(GCP_CLUSTER);\
 	mvn clean install -Dsuite=src/test/resources/basic.xml -fae
 	rm -rf $(PROJECT_ROOT)/test-cases/cells
 
 .PHONY: test-complete
 test-complete: clone-samples
 	cd $(PROJECT_ROOT)/test-cases/scenario-tests/; \
+	export IS_GCP=$(GCP_CLUSTER);\
 	mvn clean install -Dsuite=src/test/resources/complete.xml
 	rm -rf test-cases/cells
 

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/autoscaling/ScaleToZeroTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/autoscaling/ScaleToZeroTestCase.java
@@ -31,14 +31,18 @@ public class ScaleToZeroTestCase extends EmployeePortalTestCase {
 
     private static final String KUBECTL_GET_DEPLOYEMENT_EMPLOYEE_SERVICE = "kubectl get deployment employee-inst" +
             "--employee-service-rev-deployment";
-    private static final String EMPLOYEE_POD_RUNNING_OUTPUT = "employee-inst--employee-service-rev-deployment   1/1";
-    private static final String EMPLOYEE_POD_TERMINATED_OUTPUT = "employee-inst--employee-service-rev-deployment   0/0";
     private static final String CELLERY_MODIFY_SCALE_TO_ZERO = "cellery setup modify --scale-to-zero=";
+    private String employeePodRunningOutput = "employee-inst--employee-service-rev-deployment   1/1";
+    private String employeePodTerminatedOutput = "employee-inst--employee-service-rev-deployment   0/0";
 
     @BeforeClass
     public void setup() {
         this.employeeBalFile = "employee-zero.bal";
-        this.applicationName = "EmployeePortalZero";
+        this.applicationName = "EmployeePortalZero1";
+        if (Boolean.parseBoolean(System.getenv("IS_GCP"))) {
+            employeePodRunningOutput = "employee-inst--employee-service-rev-deployment   1";
+            employeePodTerminatedOutput = "employee-inst--employee-service-rev-deployment   0";
+        }
     }
 
     @Test(description = "Tests the runtime modification of enabling scale-to-zero")
@@ -56,14 +60,14 @@ public class ScaleToZeroTestCase extends EmployeePortalTestCase {
         TimeUnit.SECONDS.sleep(180);
         Process process = Runtime.getRuntime().exec(KUBECTL_GET_DEPLOYEMENT_EMPLOYEE_SERVICE);
         String errorString = "employee-service pod is not terminated";
-        readOutputResult(process, EMPLOYEE_POD_TERMINATED_OUTPUT, errorString);
+        readOutputResult(process, employeePodTerminatedOutput, errorString);
     }
 
     @Test(description = "Tests the starting of a pod after receiving a request")
     public void checkPodStart() throws Exception {
         Process process = Runtime.getRuntime().exec(KUBECTL_GET_DEPLOYEMENT_EMPLOYEE_SERVICE);
         String errorString = "employee-service pod is not running";
-        readOutputResult(process, EMPLOYEE_POD_RUNNING_OUTPUT, errorString);
+        readOutputResult(process, employeePodRunningOutput, errorString);
     }
 
     @Test(description = "Tests the runtime modification of disabling scale-to-zero")


### PR DESCRIPTION
* In GCP runtime kubectl client version is v1.12 and in other setups kubectl client version is 1.14.3. Therefore some intergration tests were failing due to a mismatch in expected output.
* Added a validation to check if the runtime is gcp and changed the expected output accordingly.