### PR TITLE
Update waiting time of cellery run

### DIFF
--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/BaseTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/BaseTestCase.java
@@ -88,7 +88,7 @@ public class BaseTestCase {
     }
 
     protected void run(String orgName, String imageName, String version, String instanceName,
-                       String[] links, boolean startDependencies, int timeoutSec)
+                       String[] links, boolean startDependencies)
             throws Exception {
         String cellImageName = getCellImageName(orgName, imageName, version);
         String command = CELLERY_RUN + " " + cellImageName + " -y >/dev/null 2>&1";
@@ -107,7 +107,7 @@ public class BaseTestCase {
         }
         Process process = Runtime.getRuntime().exec(command);
         String result = readOutputResult(process, SUCCESSFUL_RUN_MSG, "Unable to run cell: "
-                + cellImageName + " , with instance name: " + instanceName, timeoutSec);
+                + cellImageName + " , with instance name: " + instanceName, 1800);
         String instancesResult = result.substring(result.indexOf(INSTANCE_NAME_HEADING));
         if (instanceName != null && !instanceName.isEmpty()) {
             if (!instancesResult.contains(instanceName + " ")) {
@@ -200,7 +200,7 @@ public class BaseTestCase {
         private InputStream inputStream;
         private Consumer<String> consumer;
 
-        public StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
+        StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
 
             this.inputStream = inputStream;
             this.consumer = consumer;

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/EmployeePortalTestCase.java
@@ -82,8 +82,7 @@ public class EmployeePortalTestCase extends BaseTestCase {
         // Run stock cell
         run(Constants.TEST_CELL_ORG_NAME, STOCK_IMAGE_NAME, VERSION, STOCK_INSTANCE_NAME, 600);
         // Run hr cell by defining link to stock cell and starting the dependent employee cell
-        run(Constants.TEST_CELL_ORG_NAME, HR_IMAGE_NAME, VERSION, HR_INSTANCE_NAME, links, true,
-                600);
+        run(Constants.TEST_CELL_ORG_NAME, HR_IMAGE_NAME, VERSION, HR_INSTANCE_NAME, links, true);
     }
 
     @Test(description = "Sends http requests and asserts response with expected employee data")

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
@@ -97,8 +97,7 @@ public class PetStoreTestCase extends BaseTestCase {
     @Test(description = "Tests the running of pet store front end instance.")
     public void runFrontEnd() throws Exception {
         String[] links = new String[]{LINK};
-        run(Constants.CELL_ORG_NAME, FRONTEND_IMAGE_NAME, VERSION, FRONTEND_INSTANCE_NAME, links, false,
-                600);
+        run(Constants.CELL_ORG_NAME, FRONTEND_IMAGE_NAME, VERSION, FRONTEND_INSTANCE_NAME, links, false);
     }
 
     @Test(description = "Tests invoking of pet store web page.")


### PR DESCRIPTION
* When running integration tests in test-grid server it takes a long time for instances to be running and hence the successful message does not appear within the timeout. Because of that some test cases fail.
* Increased the timeout to handle this.