### PR TITLE
Update pet-store scenario selenium test

### DIFF
--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/PetStoreTestCase.java
@@ -33,7 +33,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import java.nio.file.Paths;
-import java.util.concurrent.TimeUnit;
 
 import static io.github.bonigarcia.wdm.DriverManagerType.CHROME;
 
@@ -203,10 +202,9 @@ public class PetStoreTestCase extends BaseTestCase {
      * Signs out test user to pet-store web page.
      * @param user
      *        An instance of user
+     * @throws InterruptedException if fails to sign out
      */
     private void signOut(User user) throws InterruptedException {
-        // Putting an explicit sleep of 15 seconds because test is failing in jenkins server.
-        TimeUnit.SECONDS.sleep(15);
         String idpLogoutHeaderActual = user.signOut();
         String idpLogoutHeader = "OPENID CONNECT LOGOUT";
         validateWebPage(idpLogoutHeaderActual, idpLogoutHeader, "IDP logout header " +

--- a/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/domain/User.java
+++ b/integration-tests/test-cases/scenario-tests/src/test/java/io/cellery/integration/scenario/tests/petstore/domain/User.java
@@ -142,13 +142,16 @@ public class User {
     /**
      * Sign out from pet-store.
      * @return header of idp logout screen
+     * @throws InterruptedException if fails to sign out
      */
-    public String signOut() {
+    public String signOut() throws InterruptedException {
         String userButtonXpath = "//*[@id=\"app\"]/div/header/div/div/button";
         webDriver.findElement(By.xpath(userButtonXpath)).click();
         String petStoreSignOutButtonXpath = "//*[@id=\"user-info-appbar\"]/div[2]/ul/li[2]";
         webDriver.findElement(By.xpath(petStoreSignOutButtonXpath)).click();
-        return webDriver.findElement(By.cssSelector("H2")).getText();
+        // Putting an explicit sleep of 15 seconds because test is failing in jenkins server.
+        TimeUnit.SECONDS.sleep(15);
+        return webDriver.findElement(By.xpath("/html/body/div/div/div/div/div[1]/h2")).getText();
     }
 
     /**


### PR DESCRIPTION
* Some tests are intermittently failing in server due to pet-store web elements taking too long to load.
* After clicking signout, the next page takes time time to load and hence the test fails. Added a timeout of 15 seconds to fix this issue.